### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+[![Board Status](https://dev.azure.com/erikafh/426d2338-cad6-491d-9583-37e58e6c858e/eefdbea3-7ef5-4cb8-aedb-7f99d2417067/_apis/work/boardbadge/235dca60-1e98-4083-a0b5-435308343a74)](https://dev.azure.com/erikafh/426d2338-cad6-491d-9583-37e58e6c858e/_boards/board/t/eefdbea3-7ef5-4cb8-aedb-7f99d2417067/Microsoft.RequirementCategory)
 # cursoGitHub2
- pruebas curso GitHub sesión 1
+ pruebas curso GitHub sesiï¿½n 1
  Creo Rama Dev
  Creo Rama usuario (feature-erika)
  


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/erikafh/426d2338-cad6-491d-9583-37e58e6c858e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.